### PR TITLE
Remove assert() for $authId: it is not set

### DIFF
--- a/lib/SimpleSAML/Auth/Source.php
+++ b/lib/SimpleSAML/Auth/Source.php
@@ -162,7 +162,6 @@ abstract class SimpleSAML_Auth_Source
      */
     public function initLogin($return, $errorURL = null, array $params = array())
     {
-        assert('is_string($authId)');
         assert('is_string($return) || is_array($return)');
         assert('is_string($errorURL) || is_null($errorURL)');
 


### PR DESCRIPTION
Every time login is initiated, a notice and a warning are generated:

```
[Notice] CORE/vendor/simplesamlphp/simplesamlphp/lib/SimpleSAML/Auth/Source.php(165) : assert code(1) Undefined variable: authId
[Warning] CORE/vendor/simplesamlphp/simplesamlphp/lib/SimpleSAML/Auth/Source.php(165) assert(): Assertion "is_string($authId)" failed
```

I just removed the assertion.
